### PR TITLE
Add `x-fern-server-name`

### DIFF
--- a/fern/api/openapi/openapi.json
+++ b/fern/api/openapi/openapi.json
@@ -10,11 +10,13 @@
   "servers": [
     {
       "url": "https://api.vocode.dev",
-      "description": "Production environment"
+      "description": "Production environment",
+      "x-fern-server-name": "Production",
     },
     {
       "url": "https://staging.vocode.dev",
-      "description": "Staging environment"
+      "description": "Staging environment",
+      "x-fern-server-name": "Staging"
     }
   ],
   "paths": {


### PR DESCRIPTION
Fern only considers servers that are marked with `x-fern-server-name`. Fern will default to the first server in the list, in this case `Production`.