### PR TITLE
:herb: Upgrade Python SDK Generator to `0.3.15`

### DIFF
--- a/fern/api/generators.yml
+++ b/fern/api/generators.yml
@@ -13,7 +13,7 @@ groups:
         github:
           repository: "vocodedev/vocode-api-node"
       - name: "fernapi/fern-python-sdk"
-        version: "0.3.7"
+        version: "0.3.15"
         output:
           package-name: "vocode-api"
           token: "${PYPI_TOKEN}"

--- a/fern/fern.config.json
+++ b/fern/fern.config.json
@@ -1,4 +1,4 @@
 {
-  "organization" : "vocode",
-  "version" : "0.11.6"
+  "organization": "vocode",
+  "version": "0.14.3"
 }


### PR DESCRIPTION
This new version contains several bugfixes including not sending query parameters as None.